### PR TITLE
Changes in current BlobStore implementations

### DIFF
--- a/core/src/main/java/com/expedia/blobs/core/io/AsyncSupport.java
+++ b/core/src/main/java/com/expedia/blobs/core/io/AsyncSupport.java
@@ -31,21 +31,15 @@ public abstract class AsyncSupport implements BlobStore, Closeable {
     private final ManagedAsyncOperation managedAsyncOperation;
 
     /**
-     * Initializes {@link AsyncSupport} with threads equal to the number of processors available
-     * See Runtime#availableProcessors()
-     */
-    public AsyncSupport() {
-        this(Runtime.getRuntime().availableProcessors());
-    }
-
-    /**
-     * Initializes {@link AsyncSupport} instance with a threadpool if the number of
+     * Initializes {@link AsyncSupport} instance with a threadpool
+     * and the time it waits before it is forcefully shut down(in seconds) if the number of
      * threads given are greater than zero
-     *
      * @param threadPoolSize 1 or more
+     * @param shutdownWaitInSeconds Waiting time before the threadpool is forcefully shutdown
      */
-    public AsyncSupport(int threadPoolSize) {
-        this.managedAsyncOperation = new ManagedAsyncOperation(threadPoolSize);
+
+    public AsyncSupport(int threadPoolSize, int shutdownWaitInSeconds){
+        this.managedAsyncOperation = new ManagedAsyncOperation(threadPoolSize, shutdownWaitInSeconds);
     }
 
     @Override

--- a/core/src/main/java/com/expedia/blobs/core/io/ManagedAsyncOperation.java
+++ b/core/src/main/java/com/expedia/blobs/core/io/ManagedAsyncOperation.java
@@ -35,10 +35,6 @@ class ManagedAsyncOperation implements Closeable {
     private final ExecutorService threadPool;
     private int shutdownWaitInSeconds;
 
-    ManagedAsyncOperation(int threadPoolSize) {
-        this(threadPoolSize, 60);
-    }
-
     ManagedAsyncOperation(int threadPoolSize, int shutdownWaitInSeconds) {
         Validate.isTrue(threadPoolSize > 0, "threadPoolSize cannot be 0");
         Validate.isTrue(shutdownWaitInSeconds > 0);
@@ -68,7 +64,7 @@ class ManagedAsyncOperation implements Closeable {
         threadPool.shutdown();
         try {
             if (!threadPool.awaitTermination(this.shutdownWaitInSeconds, TimeUnit.SECONDS)) {
-                LOGGER.error("AsyncStore thread pool failed to terminate in 60 seconds. Forcing shutdown");
+                LOGGER.error(String.format("AsyncStore thread pool failed to terminate in %s seconds. Forcing shutdown", this.shutdownWaitInSeconds));
                 threadPool.shutdownNow();
             }
         }

--- a/core/src/test/scala/com/expedia/blobs/core/io/AsyncSupportSpec.scala
+++ b/core/src/test/scala/com/expedia/blobs/core/io/AsyncSupportSpec.scala
@@ -16,7 +16,7 @@ object Support {
     """{"key":"value"}""".getBytes)
 }
 
-class InMemoryStore extends AsyncSupport {
+class InMemoryStore extends AsyncSupport(Runtime.getRuntime.availableProcessors(), 60) {
   
   private var blobs = List[Blob]()
   private var failBit = false
@@ -64,6 +64,7 @@ class AsyncSupportSpec extends FunSpec with GivenWhenThen with BeforeAndAfter wi
       Given(" a simple blob")
       val blob = Support.newBlob()
       When("it is stored using the given store")
+      store.throwError(false)
       store.store(blob)
       Then("it should successfully store it")
       Thread.sleep(10)

--- a/core/src/test/scala/com/expedia/blobs/core/io/ManagedAsyncOperationSpec.scala
+++ b/core/src/test/scala/com/expedia/blobs/core/io/ManagedAsyncOperationSpec.scala
@@ -10,7 +10,7 @@ class ManagedAsyncOperationSpec extends FunSpec with GivenWhenThen with BeforeAn
   describe("a class that manages async operations") {
     var asyncOperation: ManagedAsyncOperation = null
     before {
-      asyncOperation = new ManagedAsyncOperation(1)
+      asyncOperation = new ManagedAsyncOperation(1, 60)
     }
 
     after {

--- a/s3-store/src/test/scala/com/expedia/blobs/stores/aws/S3BlobStoreSpec.scala
+++ b/s3-store/src/test/scala/com/expedia/blobs/stores/aws/S3BlobStoreSpec.scala
@@ -1,9 +1,7 @@
 package com.expedia.blobs.stores.aws
 
-import java.io.{ByteArrayInputStream, IOException, InputStream}
+import java.io.{ByteArrayInputStream, InputStream}
 import java.util.Optional
-import java.util.function.BiConsumer
-
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest, S3Object, S3ObjectInputStream}
 import com.amazonaws.services.s3.transfer.{TransferManager, Upload}
@@ -23,7 +21,7 @@ object Support {
     """{"key":"value"}""".getBytes)
 }
 
-class ErrorHandlingS3BlobStore(bucket: String, trfManager: TransferManager) extends S3BlobStore(bucket, trfManager) {
+class ErrorHandlingS3BlobStore(builder: S3BlobStore.Builder) extends S3BlobStore(builder) {
   var error: Throwable = _
   override def store(b: Blob): Unit = {
     super.store(b, (t: Void, u: Throwable) => error = u)
@@ -47,16 +45,16 @@ class S3BlobStoreSpec extends FunSpec with GivenWhenThen with BeforeAndAfter wit
       When("an instance of s3 store is created")
       Then("it should fail for invalid values")
       intercept[IllegalArgumentException] {
-        new S3BlobStore(null, transferManager, poolSz)
+        new S3BlobStore.Builder(null, transferManager).withThreadPoolSize(poolSz).build()
       }
       intercept[IllegalArgumentException] {
-        new S3BlobStore(bucketName, null, poolSz)
+        new S3BlobStore.Builder(bucketName, null).withThreadPoolSize(poolSz).build()
       }
       intercept[IllegalArgumentException] {
-        new S3BlobStore(bucketName, transferManager, 0)
+        new S3BlobStore.Builder(bucketName, transferManager).withThreadPoolSize(0).build()
       }
       And("create an instance if all arguments are valid")
-      new S3BlobStore(bucketName, transferManager, poolSz) should not be null
+      new S3BlobStore.Builder(bucketName, transferManager).withThreadPoolSize(poolSz).build() should not be null
     }
   }
   it("should create a put request and submit it to transfer manager") {
@@ -64,7 +62,7 @@ class S3BlobStoreSpec extends FunSpec with GivenWhenThen with BeforeAndAfter wit
     val transferManager = mock[TransferManager]
     val poolSz = 1
     val bucketName = "blobs"
-    val store = new S3BlobStore(bucketName, transferManager, poolSz)
+    val store = new S3BlobStore.Builder(bucketName, transferManager).withThreadPoolSize(poolSz).build()
     val blob = Support.newBlob()
     val result = mock[Upload]
     expecting {
@@ -82,7 +80,7 @@ class S3BlobStoreSpec extends FunSpec with GivenWhenThen with BeforeAndAfter wit
     val transferManager = mock[TransferManager]
     val poolSz = 1
     val bucketName = "blobs"
-    val store = new S3BlobStore(bucketName, transferManager, poolSz)
+    val store = new S3BlobStore.Builder(bucketName, transferManager).withThreadPoolSize(poolSz).build()
     val blob = Support.newBlob()
     val result = mock[Upload]
     val captured = EasyMock.newCapture[PutObjectRequest]
@@ -108,7 +106,7 @@ class S3BlobStoreSpec extends FunSpec with GivenWhenThen with BeforeAndAfter wit
     val transferManager = mock[TransferManager]
     val poolSz = 1
     val bucketName = "blobs"
-    val store = new ErrorHandlingS3BlobStore(bucketName, transferManager)
+    val store = new ErrorHandlingS3BlobStore(new S3BlobStore.Builder(bucketName, transferManager))
     val blob = Support.newBlob()
     val error = new RuntimeException
     expecting {
@@ -125,7 +123,7 @@ class S3BlobStoreSpec extends FunSpec with GivenWhenThen with BeforeAndAfter wit
   it("should read a blob from s3 and return the data as expected") {
     Given("a blob store and a mock transfer manager")
     val transferManager = mock[TransferManager]
-    val store = new ErrorHandlingS3BlobStore("blobs", transferManager)
+    val store = new ErrorHandlingS3BlobStore(new S3BlobStore.Builder("blobs", transferManager))
     val s3Client = mock[AmazonS3Client]
     val s3Object = mock[S3Object]
     val objectMetadata = mock[ObjectMetadata]
@@ -153,7 +151,7 @@ class S3BlobStoreSpec extends FunSpec with GivenWhenThen with BeforeAndAfter wit
   it("should handle any exception at read and return empty object") {
     Given("a blob store that fails on read")
     val transferManager = mock[TransferManager]
-    val store = new ErrorHandlingS3BlobStore("blobs", transferManager)
+    val store = new ErrorHandlingS3BlobStore(new S3BlobStore.Builder("blobs", transferManager))
     store.throwError()
     val s3Client = mock[AmazonS3Client]
     val s3Object = mock[S3Object]
@@ -174,5 +172,27 @@ class S3BlobStoreSpec extends FunSpec with GivenWhenThen with BeforeAndAfter wit
     Thread.sleep(10)
     verify(transferManager, s3Client, s3Object, objectMetadata)
     error shouldBe a [RuntimeException]
+  }
+  it("should have autoShutdownHook when manual shutdown is disabled"){
+    Given("manual shutdown as false")
+    When("when an instance of file store is initialized")
+    val transferManager = mock[TransferManager]
+    val s3BlobStore: S3BlobStore = new S3BlobStore.Builder("blobs",transferManager).build()
+    Then("it should have a shutdown hook")
+    s3BlobStore.shutdownHook should not be (null)
+    val isHookRemoved: Boolean = Runtime.getRuntime.removeShutdownHook(s3BlobStore.shutdownHook)
+    And("it should have a shutdown hook attached to autoShutdownHooks")
+    isHookRemoved should be(true)
+  }
+  it("should have autoShutdownHook when manual shutdown is enabled"){
+    Given("manual shutdown as true")
+    When("when an instance of file store is initialized")
+    val transferManager = mock[TransferManager]
+    val s3BlobStore: S3BlobStore = new S3BlobStore.Builder("blobs",transferManager)
+      .withManualShutdown()
+      .build()
+
+    Then("it should not have shutdown hook")
+    s3BlobStore.shutdownHook should be(null)
   }
 }


### PR DESCRIPTION
This change contains 2 major changes:

1. Implementing the FileStore and S3BlobStore using builder patterns and then correcting the test cases accordingly.

2. Add a manualShutdown hook argument in the stores to allow users to specify if they want to create their own Shutdown hook for each store or if they want the library to take care of this for successfully closing the resources.