### PR TITLE
Public visibility of read/store methods

### DIFF
--- a/file-store/src/main/java/com/expedia/blobs/stores/io/FileStore.java
+++ b/file-store/src/main/java/com/expedia/blobs/stores/io/FileStore.java
@@ -65,7 +65,7 @@ public class FileStore extends AsyncSupport {
     }
 
     @Override
-    protected void storeInternal(Blob blob) {
+    public void storeInternal(Blob blob) {
         try {
             if (blob.getSize() > 0) {
                 final String blobPath = FilenameUtils.concat(directory.getAbsolutePath(), blob.getKey());
@@ -80,7 +80,7 @@ public class FileStore extends AsyncSupport {
     }
 
     @Override
-    protected Optional<Blob> readInternal(String key) {
+    public Optional<Blob> readInternal(String key) {
         try {
             final String blobPath = FilenameUtils.concat(directory.getAbsolutePath(), key);
             final String meta = FileUtils.readFileToString(new File(blobPath + ".meta.json"), Utf8);

--- a/s3-store/src/main/java/com/expedia/blobs/stores/aws/S3BlobStore.java
+++ b/s3-store/src/main/java/com/expedia/blobs/stores/aws/S3BlobStore.java
@@ -66,7 +66,7 @@ public class S3BlobStore extends AsyncSupport {
 
 
     @Override
-    protected void storeInternal(Blob blob) {
+    public void storeInternal(Blob blob) {
         try {
             final ObjectMetadata metadata = new ObjectMetadata();
             blob.getMetadata().forEach(metadata::addUserMetadata);
@@ -90,7 +90,7 @@ public class S3BlobStore extends AsyncSupport {
     }
 
     @Override
-    protected Optional<Blob> readInternal(String key) {
+    public Optional<Blob> readInternal(String key) {
         try {
             final S3Object s3Object = transferManager.getAmazonS3Client().getObject(bucketName, key);
             final Map<String, String> objectMetadata = s3Object.getObjectMetadata().getUserMetadata();


### PR DESCRIPTION
Changing the visibility of readInternal and storeInternal of each store to public due to their usage in haystack-agent through their dispatchers respectively.